### PR TITLE
fix: percentage

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -43,7 +43,7 @@ export async function compressImages(
         width:
           width ??
           (percentage && metadata.width
-            ? (metadata.width * percentage) / 100
+            ? Math.ceil(metadata.width * (percentage / 100))
             : 800),
         height,
       });


### PR DESCRIPTION
#2 fixes the bug that sharp crashes when receving a float number as width from the percentage calculation